### PR TITLE
Remove peer prior to firing the callback saying it was destroyed.

### DIFF
--- a/webrtc-client/src/main/java/fr/pchab/webrtcclient/WebRtcClient.java
+++ b/webrtc-client/src/main/java/fr/pchab/webrtcclient/WebRtcClient.java
@@ -194,8 +194,8 @@ public class WebRtcClient {
         @Override
         public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
             if(iceConnectionState == PeerConnection.IceConnectionState.DISCONNECTED) {
-                mListener.onStatusChanged("DISCONNECTED");
                 removePeer(id);
+                mListener.onStatusChanged("DISCONNECTED");
             }
         }
 


### PR DESCRIPTION
This fixes an issue where the client expects the peer to be destroyed in the `onStatusChanged()` callback.
